### PR TITLE
Improve cross-platform event handling 

### DIFF
--- a/src/main/scala/introprog/PixelWindow.scala
+++ b/src/main/scala/introprog/PixelWindow.scala
@@ -8,6 +8,34 @@ object PixelWindow {
   /** Idle waiting for `millis` milliseconds. */
   def delay(millis: Long): Unit = Thread.sleep(millis)
 
+  /** A map with string representations for special key codes. */
+  private val keyTextLookup: Map[Int, String] = {
+    import java.awt.event.KeyEvent._
+    Map(
+      VK_META       -> "Meta",
+      VK_CONTROL    -> "Ctrl",
+      VK_ALT        -> "Alt",
+      VK_ALT_GRAPH  -> "Alt Gr",
+      VK_SHIFT      -> "Shift",
+      VK_CAPS_LOCK  -> "Caps Lock",
+      VK_ENTER      -> "Enter",
+      VK_DELETE     -> "Delete",
+      VK_BACK_SPACE -> "Backspace",
+      VK_ESCAPE     -> "Esc",
+      VK_RIGHT      -> "Right",
+      VK_LEFT       -> "Left",
+      VK_UP         -> "Up",
+      VK_DOWN       -> "Down",
+      VK_PAGE_UP    -> "Page up",
+      VK_PAGE_DOWN  -> "Page down",
+      VK_HOME       -> "Home",
+      VK_END        -> "End",
+      VK_CLEAR      -> "Clear",
+      VK_TAB        -> "Tab",
+      VK_SPACE      -> " ",
+    )
+  }
+
   /** An object with integers representing events that can happen in a PixelWindow. */
   object Event {
     /** An integer representing a key down event.
@@ -138,7 +166,7 @@ class PixelWindow(
 
     case ke: java.awt.event.KeyEvent =>
       if (ke.getKeyChar == java.awt.event.KeyEvent.CHAR_UNDEFINED || ke.getKeyChar < ' ')
-        _lastKeyText = java.awt.event.KeyEvent.getKeyText(ke.getKeyCode)
+            _lastKeyText = PixelWindow.keyTextLookup.getOrElse(ke.getKeyCode, java.awt.event.KeyEvent.getKeyText(ke.getKeyCode))
       else _lastKeyText = ke.getKeyChar.toString
 
       ke.getID match {
@@ -164,7 +192,7 @@ class PixelWindow(
   /** Return `true` if `(x, y)` is inside windows borders else `false`. */
   def isInside(x: Int, y: Int): Boolean = x >= 0 && x < width && y >= 0 && y < height
 
-  private def requireInside(x: Int, y: Int): Unit = 
+  private def requireInside(x: Int, y: Int): Unit =
     require(isInside(x,y), s"(x=$x, y=$y) out of window bounds (0 until $width, 0 until $height)")
 
   /** Wait for next event until `timeoutInMillis` milliseconds.
@@ -193,7 +221,7 @@ class PixelWindow(
       g.fillRect(x, y, width, height)
     }
 
-  /** Set the color of the pixel at `(x, y)`. 
+  /** Set the color of the pixel at `(x, y)`.
     *
     * If (x, y) is outside of window bounds then an IllegalArgumentException is thrown.
     */
@@ -204,7 +232,7 @@ class PixelWindow(
     }
   }
 
-  /** Clear the pixel at `(x, y)` using the `background` class parameter. 
+  /** Clear the pixel at `(x, y)` using the `background` class parameter.
     *
     * If (x, y) is outside of window bounds then an IllegalArgumentException is thrown.
     */
@@ -215,7 +243,7 @@ class PixelWindow(
     }
   }
 
-  /** Return the color of the pixel at `(x, y)`. 
+  /** Return the color of the pixel at `(x, y)`.
     *
     * If (x, y) is outside of window bounds then an IllegalArgumentException is thrown.
     */
@@ -226,7 +254,7 @@ class PixelWindow(
 
   /** Set the PixelWindow frame title. */
   def setTitle(title: String): Unit = Swing { frame.setTitle(title) }
-  
+
   /** Show the window. Has no effect if the window is already visible. */
   def show(): Unit = Swing { frame.setVisible(true) }
 

--- a/src/main/scala/introprog/PixelWindow.scala
+++ b/src/main/scala/introprog/PixelWindow.scala
@@ -13,6 +13,7 @@ object PixelWindow {
     import java.awt.event.KeyEvent._
     Map(
       VK_META       -> "Meta",
+      VK_WINDOWS    -> "Meta",
       VK_CONTROL    -> "Ctrl",
       VK_ALT        -> "Alt",
       VK_ALT_GRAPH  -> "Alt Gr",
@@ -166,7 +167,7 @@ class PixelWindow(
 
     case ke: java.awt.event.KeyEvent =>
       if (ke.getKeyChar == java.awt.event.KeyEvent.CHAR_UNDEFINED || ke.getKeyChar < ' ')
-            _lastKeyText = PixelWindow.keyTextLookup.getOrElse(ke.getKeyCode, java.awt.event.KeyEvent.getKeyText(ke.getKeyCode))
+        _lastKeyText = PixelWindow.keyTextLookup.getOrElse(ke.getKeyCode, java.awt.event.KeyEvent.getKeyText(ke.getKeyCode))
       else _lastKeyText = ke.getKeyChar.toString
 
       ke.getID match {

--- a/src/main/scala/introprog/PixelWindow.scala
+++ b/src/main/scala/introprog/PixelWindow.scala
@@ -294,6 +294,8 @@ class PixelWindow(
     Swing.init() // first time calls setPlatformSpecificLookAndFeel
     javax.swing.JFrame.setDefaultLookAndFeelDecorated(true)
 
+    frame.setFocusTraversalKeysEnabled(false);
+
     frame.addWindowListener(new java.awt.event.WindowAdapter {
       override def windowClosing(e: java.awt.event.WindowEvent): Unit = {
         frame.setVisible(false)


### PR DESCRIPTION
Using a `Map` for key code lookup in `handleEvent` unifies event handling across platforms, fixing issues with special keys on macOS. Calling `setFocusTraversalKeysEnabled(false)` on `frame` in `initFrame` fixes `TAB` strokes not being recognized. This is tested with labs on all major platforms.

Fixes #11, fixes #1.