### PR TITLE
Update WSL detection to use introprog.IO instead of grep. fix #29

### DIFF
--- a/src/main/scala/introprog/Swing.scala
+++ b/src/main/scala/introprog/Swing.scala
@@ -38,15 +38,13 @@ object Swing {
     * Can be used to detect if we are on WSL instead of "real" linux/ubuntu.
     */
   private def isInProc(parts: String*): Boolean = {
-    val searchExpression = parts.mkString("|")
-    val cmd = Seq(
-      "grep", 
-      "--ignore-case", "--perl-regexp", "--no-messages", "--silent", 
-      searchExpression, 
-      "/proc/version"
-    )
-    val process = sys.process.Process(cmd)
-    util.Try(process.! == 0).getOrElse(false)
+    import util.{Try, Success, Failure}
+    val partsLowerCase = parts.map(_.toLowerCase)
+    
+    Try(IO.loadString("/proc/version").toLowerCase) match {
+      case Success(s) => partsLowerCase.exists(s.contains(_))
+      case Failure(_) => false
+    }
   }
 
   private var isInit = false

--- a/src/main/scala/introprog/Swing.scala
+++ b/src/main/scala/introprog/Swing.scala
@@ -37,14 +37,10 @@ object Swing {
   /** Check whether `/proc/version` on this filesystem contains any of the strings in `parts`. 
     * Can be used to detect if we are on WSL instead of "real" linux/ubuntu.
     */
-  private def isInProc(parts: String*): Boolean = {
-    import util.{Try, Success, Failure}
-    
-    Try(IO.loadString("/proc/version").toLowerCase) match {
-      case Success(proc) => parts.map(_.toLowerCase).exists(proc.contains(_))
-      case Failure(_) => false
-    }
-  }
+  private def isInProc(parts: String*): Boolean =
+    util.Try(parts.map(_.toLowerCase)
+    .exists(IO.loadString("/proc/version").toLowerCase.contains(_)))
+    .getOrElse(false)
 
   private var isInit = false
 

--- a/src/main/scala/introprog/Swing.scala
+++ b/src/main/scala/introprog/Swing.scala
@@ -39,10 +39,9 @@ object Swing {
     */
   private def isInProc(parts: String*): Boolean = {
     import util.{Try, Success, Failure}
-    val partsLowerCase = parts.map(_.toLowerCase)
     
     Try(IO.loadString("/proc/version").toLowerCase) match {
-      case Success(s) => partsLowerCase.exists(s.contains(_))
+      case Success(proc) => parts.map(_.toLowerCase).exists(proc.contains(_))
       case Failure(_) => false
     }
   }

--- a/src/main/scala/introprog/Swing.scala
+++ b/src/main/scala/introprog/Swing.scala
@@ -39,7 +39,7 @@ object Swing {
     */
   private def isInProc(parts: String*): Boolean =
     util.Try(parts.map(_.toLowerCase)
-    .exists(IO.loadString("/proc/version").toLowerCase.contains(_)))
+    .exists(part => IO.loadString("/proc/version").toLowerCase.contains(part)))
     .getOrElse(false)
 
   private var isInit = false


### PR DESCRIPTION
Small change to function `isInProc()` to use `introprog.IO` instead of running grep on the users system. See discussion in issue #29.