### PR TITLE
Added compiler flags again

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,6 +32,8 @@ ThisBuild / versionPolicyIntention := Compatibility.None
 
 ThisBuild / scalacOptions ++= Seq(
   "-encoding", "UTF-8",
+  "-unchecked",
+  "-deprecation",
 //  "-Xfuture",
 //  "-Yno-adapted-args",
 //  "-Ywarn-dead-code",


### PR DESCRIPTION
Actually, I did some more testing, and these flags are only ignored when running `sbt doc`, they are still used when compiling the code.