### PR TITLE
Give the super key a name distinct from the meta key

### DIFF
--- a/src/main/scala/introprog/PixelWindow.scala
+++ b/src/main/scala/introprog/PixelWindow.scala
@@ -13,7 +13,7 @@ object PixelWindow:
     import java.awt.event.KeyEvent._
     Map(
       VK_META       -> "Meta",
-      VK_WINDOWS    -> "Meta",
+      VK_WINDOWS    -> "Super",
       VK_CONTROL    -> "Ctrl",
       VK_ALT        -> "Alt",
       VK_ALT_GRAPH  -> "Alt Gr",


### PR DESCRIPTION
closes #54

I changed the name to `"Super"`, I can edit the PR it if a better name is decided upon.